### PR TITLE
Removed duplicate SpaceBeforeSquareBrackets definition

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -162,7 +162,6 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2


### PR DESCRIPTION
The autoformatter is currently not working because of a duplicate definition of `SpaceBeforeSquareBrackets` in _.clang-format_.
I removed one of the definition. This fixes the autoformatter.